### PR TITLE
added the section 3D MEMBRANE ELEMENTS - QUADRILATERAL

### DIFF
--- a/data/abaqus_elements.toml
+++ b/data/abaqus_elements.toml
@@ -121,6 +121,30 @@ type = "Hex20"
 description = "20-node quadratic brick, reduced integration and hybrid. Combines computational efficiency of reduced integration with hybrid formulation for nearly incompressible materials."
 
 # =============================================================================
+# 3D MEMBRANE ELEMENTS - QUADRILATERAL
+# =============================================================================
+
+[M3D4]
+nodes = 9
+type = "Quad4"
+description = "4-node three-dimensional membrane linear element fully integrated"
+
+[M3D4R]
+nodes = 9
+type = "Quad4"
+description = "4-node three-dimensional membrane linear element reduced integration"
+
+[M3D9]
+nodes = 9
+type = "Quad9"
+description = "9-node three-dimensional membrane quadratic element fully integrated"
+
+[M3D9R]
+nodes = 9
+type = "Quad9"
+description = "9-node three-dimensional membrane quadratic element reduced integration"
+
+# =============================================================================
 # COHESIVE ELEMENTS
 # =============================================================================
 
@@ -302,6 +326,11 @@ description = "2-node linear 2D truss element. Models pin-jointed structures tha
 nodes = 2
 type = "Seg2"
 description = "2-node linear 3D truss element. Models pin-jointed spatial structures carrying only axial loads. No bending, torsion, or shear stiffness. Common in space frames and tower structures."
+
+[T3D3]
+nodes = 3
+type = "Seg3"
+description = "3-node quadratic 3D truss element. Models pin-jointed spatial structures carrying only axial loads. No bending, torsion, or shear stiffness. Common in space frames and tower structures."
 
 [B31]
 nodes = 2


### PR DESCRIPTION
added the following elements: M3D4, M3D4R, M3D9, M3D9R

when doing the tests with julia --project=. test/runtests.jl it fails but I am not sure why. However it would fail the test even before the modification. Here is the beginning of the error message

```
┌ Error: Error parsing section ELEMENT
│   exception =
│    Unknown ABAQUS element type: UNKNOWN_ELEM_XYZ
│    
│    This element type is not in the element database. You have two options:
│    
│    1. TEMPORARY FIX - Register the element dynamically before reading the mesh:
│       
│       using AbaqusReader
│       register_element!("UNKNOWN_ELEM_XYZ", num_nodes, "ElementType")
│       
│       Where:
│       - num_nodes: number of nodes in the element (e.g., 4, 8, 10, 20)
│       - ElementType: mesh topology (e.g., "Tet4", "Hex8", "Tri3", "Quad4")
│       
│       Example: register_element!("C3D10I", 10, "Tet10")
│    
│    2. PERMANENT FIX - Add the element to the database:
│       
│       a) Edit data/abaqus_elements.toml in the AbaqusReader.jl repository
│       b) Add a new section following the existing format:
│          
│          [UNKNOWN_ELEM_XYZ]
│          nodes = <number_of_nodes>
│          type = "<topology_type>"
│          description = "Element description from ABAQUS documentation"
│       
│       c) Run tests to verify: julia --project=. test/runtests.jl
│       d) Submit a pull request to: https://github.com/ahojukka5/AbaqusReader.jl
│    
│    See https://github.com/ahojukka5/AbaqusReader.jl#element-types for more information.
│    
└ @ AbaqusReader ~/github/AbaqusReader.jl/src/mesh/parsers.jl:277
```