### PR TITLE
fix(assembly): apply instance transforms when flattening

### DIFF
--- a/src/mesh/assembly_parser.jl
+++ b/src/mesh/assembly_parser.jl
@@ -1,31 +1,275 @@
 # This file is a part of JuliaFEM.
 # License is MIT: see https://github.com/JuliaFEM/AbaqusReader.jl/blob/master/LICENSE
 
+function instance_data_lines(lines, first_line::Int, last_line::Int)
+    data = String[]
+    for index in first_line:last_line
+        line = strip(lines[index])
+        isempty(line) && continue
+        startswith(line, "**") && continue
+        startswith(line, "*") && throw(ArgumentError(
+            "unexpected keyword inside *INSTANCE placement data: $line",
+        ))
+        push!(data, line)
+    end
+    return data
+end
+
+function instance_numbers(
+    line::AbstractString,
+    expected::Int,
+    description::AbstractString,
+)
+    fields = [
+        strip(field) for field in split(String(line), ',')
+        if !isempty(strip(field))
+    ]
+    length(fields) == expected || throw(ArgumentError(
+        "$description requires $expected numeric values, got $(length(fields))",
+    ))
+    try
+        return parse.(Float64, fields)
+    catch exception
+        throw(ArgumentError(
+            "$description contains a non-numeric value: $(sprint(showerror, exception))",
+        ))
+    end
+end
+
+function parse_instance_placement(data::Vector{String})
+    length(data) <= 2 || throw(ArgumentError(
+        "*INSTANCE placement accepts at most one translation and one rotation line",
+    ))
+
+    translation = [0.0, 0.0, 0.0]
+    rotation = nothing
+    if length(data) == 1
+        values = [
+            strip(field) for field in split(data[1], ',')
+            if !isempty(strip(field))
+        ]
+        if length(values) == 3
+            translation = instance_numbers(data[1], 3, "instance translation")
+        elseif length(values) == 7
+            rotation_values = instance_numbers(data[1], 7, "instance rotation")
+            rotation = Dict{String,Any}(
+                "axis_start" => rotation_values[1:3],
+                "axis_end" => rotation_values[4:6],
+                "angle_degrees" => rotation_values[7],
+            )
+        else
+            throw(ArgumentError(
+                "single-line *INSTANCE placement must contain 3 translation " *
+                "or 7 rotation values",
+            ))
+        end
+    elseif length(data) == 2
+        translation = instance_numbers(data[1], 3, "instance translation")
+        rotation_values = instance_numbers(data[2], 7, "instance rotation")
+        rotation = Dict{String,Any}(
+            "axis_start" => rotation_values[1:3],
+            "axis_end" => rotation_values[4:6],
+            "angle_degrees" => rotation_values[7],
+        )
+    end
+
+    return translation, rotation
+end
+
+function find_end_instance(lines, start_index::Int)
+    for index in (start_index + 1):length(lines)
+        startswith(uppercase(strip(lines[index])), "*END INSTANCE") &&
+            return index
+    end
+    throw(ArgumentError("*INSTANCE section is missing *END INSTANCE"))
+end
+
+function parse_instance_record(lines, start_index::Int, end_index::Int)
+    header = strip(lines[start_index])
+    name_match = match(r"NAME\s*=\s*([^,\s]+)"i, header)
+    part_match = match(r"PART\s*=\s*([^,\s]+)"i, header)
+    name_match === nothing && throw(ArgumentError(
+        "*INSTANCE requires a NAME parameter",
+    ))
+    part_match === nothing && throw(ArgumentError(
+        "*INSTANCE requires a PART parameter",
+    ))
+
+    translation, rotation = parse_instance_placement(instance_data_lines(
+        lines,
+        start_index + 1,
+        end_index - 1,
+    ))
+    return Dict{String,Any}(
+        "name" => String(name_match[1]),
+        "part" => String(part_match[1]),
+        "translation" => translation,
+        "rotation" => rotation,
+    )
+end
+
+function coordinates3(coordinates)
+    isempty(coordinates) && throw(ArgumentError(
+        "instance node has no coordinates",
+    ))
+    return (
+        Float64(coordinates[1]),
+        length(coordinates) >= 2 ? Float64(coordinates[2]) : 0.0,
+        length(coordinates) >= 3 ? Float64(coordinates[3]) : 0.0,
+    )
+end
+
+function rotate_instance_point(point, rotation::AbstractDict)
+    axis_start_values = rotation["axis_start"]
+    axis_end_values = rotation["axis_end"]
+    axis_start = coordinates3(axis_start_values)
+    axis_end = coordinates3(axis_end_values)
+    axis = (
+        axis_end[1] - axis_start[1],
+        axis_end[2] - axis_start[2],
+        axis_end[3] - axis_start[3],
+    )
+    axis_length = sqrt(axis[1]^2 + axis[2]^2 + axis[3]^2)
+    axis_length > eps(Float64) || throw(ArgumentError(
+        "instance rotation axis must have nonzero length",
+    ))
+    unit_axis = (
+        axis[1] / axis_length,
+        axis[2] / axis_length,
+        axis[3] / axis_length,
+    )
+    relative = (
+        point[1] - axis_start[1],
+        point[2] - axis_start[2],
+        point[3] - axis_start[3],
+    )
+    cosine = cosd(Float64(rotation["angle_degrees"]))
+    sine = sind(Float64(rotation["angle_degrees"]))
+    cross = (
+        unit_axis[2] * relative[3] - unit_axis[3] * relative[2],
+        unit_axis[3] * relative[1] - unit_axis[1] * relative[3],
+        unit_axis[1] * relative[2] - unit_axis[2] * relative[1],
+    )
+    projection = unit_axis[1] * relative[1] +
+        unit_axis[2] * relative[2] +
+        unit_axis[3] * relative[3]
+    scale = 1.0 - cosine
+    return (
+        axis_start[1] + relative[1] * cosine + cross[1] * sine +
+            unit_axis[1] * projection * scale,
+        axis_start[2] + relative[2] * cosine + cross[2] * sine +
+            unit_axis[2] * projection * scale,
+        axis_start[3] + relative[3] * cosine + cross[3] * sine +
+            unit_axis[3] * projection * scale,
+    )
+end
+
+function transform_instance_coordinates(coordinates, instance::AbstractDict)
+    point = coordinates3(coordinates)
+    translation = instance["translation"]
+    translated = (
+        point[1] + Float64(translation[1]),
+        point[2] + Float64(translation[2]),
+        point[3] + Float64(translation[3]),
+    )
+    rotation = instance["rotation"]
+    transformed = rotation === nothing ? translated :
+        rotate_instance_point(translated, rotation)
+    return collect(transformed)
+end
+
+function flatten_part!(
+    result::Dict{String,Any},
+    part_name::AbstractString,
+    prefix::AbstractString,
+    part_data::AbstractDict,
+    instance,
+    node_offset::Int,
+    element_offset::Int,
+)
+    @debug "Flattening PART $part_name as $prefix ($(length(part_data["nodes"])) nodes, $(length(part_data["elements"])) elements)"
+
+    for (node_id, coordinates) in sort(collect(part_data["nodes"]); by=first)
+        global_node_id = node_id + node_offset
+        result["nodes"][global_node_id] = instance === nothing ?
+            copy(coordinates) : transform_instance_coordinates(coordinates, instance)
+    end
+
+    for (element_id, connectivity) in sort(
+        collect(part_data["elements"]);
+        by=first,
+    )
+        global_element_id = element_id + element_offset
+        result["elements"][global_element_id] = [
+            node_id + node_offset for node_id in connectivity
+        ]
+        result["element_types"][global_element_id] =
+            part_data["element_types"][element_id]
+        result["element_codes"][global_element_id] =
+            part_data["element_codes"][element_id]
+    end
+
+    for (set_name, element_ids) in sort(
+        collect(part_data["element_sets"]);
+        by=first,
+    )
+        result["element_sets"]["$(prefix).$(set_name)"] = [
+            element_id + element_offset for element_id in element_ids
+        ]
+    end
+    for (set_name, node_ids) in sort(
+        collect(part_data["node_sets"]);
+        by=first,
+    )
+        result["node_sets"]["$(prefix).$(set_name)"] = [
+            node_id + node_offset for node_id in node_ids
+        ]
+    end
+    for (surface_name, surface_pairs) in sort(
+        collect(part_data["surface_sets"]);
+        by=first,
+    )
+        prefixed_name = "$(prefix).$(surface_name)"
+        result["surface_sets"][prefixed_name] = [
+            (element_id + element_offset, side)
+            for (element_id, side) in surface_pairs
+        ]
+        if haskey(part_data["surface_types"], surface_name)
+            result["surface_types"][prefixed_name] =
+                part_data["surface_types"][surface_name]
+        end
+    end
+
+    next_node_offset = isempty(part_data["nodes"]) ? node_offset :
+        maximum(keys(result["nodes"]))
+    next_element_offset = isempty(part_data["elements"]) ? element_offset :
+        maximum(keys(result["elements"]))
+    return next_node_offset, next_element_offset
+end
+
 """
     parse_assembly_mesh(io::IO; verbose=true)
 
 Parse ABAQUS input files with modern PART/ASSEMBLY structure.
 
 This parser handles structured ABAQUS files that use:
-- *PART sections to define individual parts with their own nodes/elements
-- *ASSEMBLY section to combine parts together
+- `*PART` sections to define reusable local meshes;
+- `*INSTANCE` sections to place parts with optional translation and rotation;
+- `*ASSEMBLY` sections to combine instances.
 
-Returns a dictionary with:
-- "parts": Dict{String, Dict} - Each part's mesh data (nodes, elements, etc.)
-- "assembly": Dict - Assembly-level data (sets, instances, etc.)
-- "nodes": Dict - Flattened nodes from all parts
-- "elements": Dict - Flattened elements from all parts
-- "element_types": Dict - Element types for all elements
-
-The flattened mesh allows backward compatibility with code expecting the flat format.
+Returns a dictionary with part data, assembly instance metadata, and a flattened
+mesh. When instances are declared, flattened set and surface names are prefixed
+with the instance name. PART-only input retains the legacy part-name prefix.
 """
 function parse_assembly_mesh(io::IO; verbose=true)
     lines = readlines(io)
 
-    # Initialize result structure
     result = Dict{String,Any}(
         "parts" => Dict{String,Dict{String,Any}}(),
-        "assembly" => Dict{String,Any}(),
+        "assembly" => Dict{String,Any}(
+            "instances" => Dict{String,Dict{String,Any}}(),
+        ),
+        "instance_parts" => Dict{String,String}(),
         "nodes" => Dict{Int,Vector{Float64}}(),
         "elements" => Dict{Int,Vector{Int}}(),
         "element_types" => Dict{Int,Symbol}(),
@@ -33,29 +277,28 @@ function parse_assembly_mesh(io::IO; verbose=true)
         "element_sets" => Dict{String,Vector{Int}}(),
         "node_sets" => Dict{String,Vector{Int}}(),
         "surface_sets" => Dict{String,Vector{Tuple{Int,Symbol}}}(),
-        "surface_types" => Dict{String,Symbol}()
+        "surface_types" => Dict{String,Symbol}(),
     )
 
     current_part = nothing
     in_assembly = false
-    i = 1
+    index = 1
 
-    while i <= length(lines)
-        line = strip(lines[i])
-
-        # Skip empty lines and comments
+    while index <= length(lines)
+        line = strip(lines[index])
         if isempty(line) || startswith(line, "**")
-            i += 1
+            index += 1
             continue
         end
 
         line_upper = uppercase(line)
-
-        # Detect *PART
         if startswith(line_upper, "*PART")
-            m = match(r"NAME\s*=\s*([^,\s]+)"i, line)
-            if m !== nothing
-                part_name = m[1]
+            name_match = match(r"NAME\s*=\s*([^,\s]+)"i, line)
+            if name_match !== nothing
+                part_name = String(name_match[1])
+                haskey(result["parts"], part_name) && throw(ArgumentError(
+                    "duplicate PART name: $part_name",
+                ))
                 @debug "Starting PART: $part_name"
                 current_part = part_name
                 result["parts"][part_name] = Dict{String,Any}(
@@ -66,50 +309,67 @@ function parse_assembly_mesh(io::IO; verbose=true)
                     "element_sets" => Dict{String,Vector{Int}}(),
                     "node_sets" => Dict{String,Vector{Int}}(),
                     "surface_sets" => Dict{String,Vector{Tuple{Int,Symbol}}}(),
-                    "surface_types" => Dict{String,Symbol}()
+                    "surface_types" => Dict{String,Symbol}(),
                 )
             end
-            i += 1
+            index += 1
             continue
         end
 
-        # Detect *END PART
         if startswith(line_upper, "*END PART")
             @debug "Ending PART: $current_part"
             current_part = nothing
-            i += 1
+            index += 1
             continue
         end
 
-        # Detect *ASSEMBLY
         if startswith(line_upper, "*ASSEMBLY")
             @debug "Starting ASSEMBLY"
             in_assembly = true
             current_part = nothing
-            i += 1
+            index += 1
             continue
         end
 
-        # Detect *END ASSEMBLY
         if startswith(line_upper, "*END ASSEMBLY")
             @debug "Ending ASSEMBLY"
             in_assembly = false
-            i += 1
+            index += 1
             continue
         end
 
-        # Find the next keyword
-        next_keyword_idx = i + 1
-        while next_keyword_idx <= length(lines)
-            next_line = strip(lines[next_keyword_idx])
-            if !isempty(next_line) && startswith(next_line, "*") && !startswith(next_line, "**")
-                break
-            end
-            next_keyword_idx += 1
+        if startswith(line_upper, "*INSTANCE")
+            in_assembly || throw(ArgumentError(
+                "*INSTANCE must appear inside *ASSEMBLY",
+            ))
+            end_index = find_end_instance(lines, index)
+            instance = parse_instance_record(lines, index, end_index)
+            instance_name = String(instance["name"])
+            instances = result["assembly"]["instances"]
+            haskey(instances, instance_name) && throw(ArgumentError(
+                "duplicate INSTANCE name: $instance_name",
+            ))
+            instances[instance_name] = instance
+            index = end_index + 1
+            continue
         end
 
-        # Determine target dictionary (part-specific or assembly/global)
-        target_dict = if current_part !== nothing
+        if startswith(line_upper, "*END INSTANCE")
+            index += 1
+            continue
+        end
+
+        next_keyword_index = index + 1
+        while next_keyword_index <= length(lines)
+            next_line = strip(lines[next_keyword_index])
+            if !isempty(next_line) && startswith(next_line, "*") &&
+               !startswith(next_line, "**")
+                break
+            end
+            next_keyword_index += 1
+        end
+
+        target = if current_part !== nothing
             result["parts"][current_part]
         elseif in_assembly
             result["assembly"]
@@ -117,7 +377,6 @@ function parse_assembly_mesh(io::IO; verbose=true)
             result
         end
 
-        # Parse sections using the existing parser
         keyword = :UNKNOWN
         if startswith(line_upper, "*NODE")
             keyword = :NODE
@@ -133,74 +392,60 @@ function parse_assembly_mesh(io::IO; verbose=true)
 
         if keyword != :UNKNOWN
             try
-                parse_section(target_dict, lines, keyword, i, next_keyword_idx - 1, Val{keyword})
-            catch e
+                parse_section(
+                    target,
+                    lines,
+                    keyword,
+                    index,
+                    next_keyword_index - 1,
+                    Val{keyword},
+                )
+            catch exception
                 if verbose
-                    @warn "Error parsing section $keyword in part/assembly" exception = e
+                    @warn "Error parsing section $keyword in part/assembly" exception
                 end
             end
         end
 
-        i = next_keyword_idx
+        index = next_keyword_index
     end
 
-    # Flatten all parts into global nodes/elements for backward compatibility
     node_offset = 0
     element_offset = 0
-
-    for part_name in sort(collect(keys(result["parts"])))
-        part_data = result["parts"][part_name]
-        @debug "Flattening PART: $part_name ($(length(part_data["nodes"])) nodes, $(length(part_data["elements"])) elements)"
-
-        # Merge nodes
-        for (node_id, coords) in part_data["nodes"]
-            result["nodes"][node_id+node_offset] = coords
+    instances = result["assembly"]["instances"]
+    if isempty(instances)
+        for part_name in sort(collect(keys(result["parts"])))
+            node_offset, element_offset = flatten_part!(
+                result,
+                part_name,
+                part_name,
+                result["parts"][part_name],
+                nothing,
+                node_offset,
+                element_offset,
+            )
         end
-
-        # Merge elements (adjusting node references)
-        for (elem_id, connectivity) in part_data["elements"]
-            adjusted_connectivity = [node_id + node_offset for node_id in connectivity]
-            result["elements"][elem_id+element_offset] = adjusted_connectivity
-            result["element_types"][elem_id+element_offset] = part_data["element_types"][elem_id]
-            result["element_codes"][elem_id+element_offset] = part_data["element_codes"][elem_id]
-        end
-
-        # Merge element sets
-        for (set_name, elem_ids) in part_data["element_sets"]
-            prefixed_name = "$(part_name).$(set_name)"
-            adjusted_ids = [id + element_offset for id in elem_ids]
-            result["element_sets"][prefixed_name] = adjusted_ids
-        end
-
-        # Merge node sets
-        for (set_name, node_ids) in part_data["node_sets"]
-            prefixed_name = "$(part_name).$(set_name)"
-            adjusted_ids = [id + node_offset for id in node_ids]
-            result["node_sets"][prefixed_name] = adjusted_ids
-        end
-
-        # Merge surface sets
-        for (surface_name, surface_pairs) in part_data["surface_sets"]
-            prefixed_name = "$(part_name).$(surface_name)"
-            adjusted_pairs = [(elid + element_offset, side) for (elid, side) in surface_pairs]
-            result["surface_sets"][prefixed_name] = adjusted_pairs
-
-            if haskey(part_data["surface_types"], surface_name)
-                result["surface_types"][prefixed_name] = part_data["surface_types"][surface_name]
-            end
-        end
-
-        # Update offsets for next part
-        if !isempty(part_data["nodes"])
-            node_offset = maximum(keys(result["nodes"]))
-        end
-        if !isempty(part_data["elements"])
-            element_offset = maximum(keys(result["elements"]))
+    else
+        for instance_name in sort(collect(keys(instances)))
+            instance = instances[instance_name]
+            part_name = String(instance["part"])
+            haskey(result["parts"], part_name) || throw(ArgumentError(
+                "INSTANCE $instance_name references unknown PART $part_name",
+            ))
+            result["instance_parts"][instance_name] = part_name
+            node_offset, element_offset = flatten_part!(
+                result,
+                part_name,
+                instance_name,
+                result["parts"][part_name],
+                instance,
+                node_offset,
+                element_offset,
+            )
         end
     end
 
     @debug "Flattened mesh: $(length(result["nodes"])) nodes, $(length(result["elements"])) elements"
-
     return result
 end
 
@@ -208,14 +453,12 @@ end
     detect_assembly_format(lines) -> Bool
 
 Detect if the input file uses the modern PART/ASSEMBLY structure.
-Returns true if *PART keyword is found.
+Returns true if `*PART` is found.
 """
 function detect_assembly_format(lines)
     for line in lines
         line_upper = uppercase(strip(String(line)))
-        if startswith(line_upper, "*PART")
-            return true
-        end
+        startswith(line_upper, "*PART") && return true
     end
     return false
 end

--- a/test/test_multiple_parts.jl
+++ b/test/test_multiple_parts.jl
@@ -4,84 +4,163 @@
 using AbaqusReader
 using Test
 
-@testset "Multiple parts mesh - PART/ASSEMBLY structure" begin
-    # Minimal example of ABAQUS structured format with multiple parts
-    inp_content = """
+@testset "Assembly instances preserve names and translated placement" begin
+    input = """
     *HEADING
-    Model with multiple parts
-    *PART,NAME=PART1
+    Model with translated instances
+    *PART, NAME=PART1
     *NODE
     1, 0.0, 0.0, 0.0
     2, 1.0, 0.0, 0.0
     3, 1.0, 1.0, 0.0
     4, 0.0, 1.0, 0.0
-    *ELEMENT,TYPE=CPS4,ELSET=EPART1
+    *NSET, NSET=CORNER
+    1
+    *ELEMENT, TYPE=CPS4, ELSET=EPART1
     1, 1, 2, 3, 4
-    *SURFACE,TYPE=ELEMENT,NAME=LOADP1
+    *SURFACE, TYPE=ELEMENT, NAME=LOADP1
     1, S1
     *END PART
-    *PART,NAME=PART2
+    *PART, NAME=PART2
     *NODE
-    1, 2.0, 0.0, 0.0
-    2, 3.0, 0.0, 0.0
-    3, 3.0, 1.0, 0.0
-    4, 2.0, 1.0, 0.0
-    *ELEMENT,TYPE=CPS4,ELSET=EPART2
+    1, 0.0, 0.0, 0.0
+    2, 1.0, 0.0, 0.0
+    3, 1.0, 1.0, 0.0
+    4, 0.0, 1.0, 0.0
+    *ELEMENT, TYPE=CPS4, ELSET=EPART2
     1, 1, 2, 3, 4
-    *SURFACE,TYPE=ELEMENT,NAME=LOADP2
+    *SURFACE, TYPE=ELEMENT, NAME=LOADP2
     1, S1
     *END PART
-    *ASSEMBLY,NAME=ASSEMBLY1
-    *INSTANCE,NAME=INST1,PART=PART1
+    *ASSEMBLY, NAME=ASSEMBLY1
+    *INSTANCE, NAME=INST1, PART=PART1
     *END INSTANCE
-    *INSTANCE,NAME=INST2,PART=PART2
-    1.0, 0.0, 0.0
+    *INSTANCE, NAME=INST2, PART=PART2
+    2.0, 0.0, 0.0
     *END INSTANCE
     *END ASSEMBLY
     """
 
-    # Parse with new assembly parser
-    mesh = abaqus_parse_mesh(inp_content)
+    mesh = abaqus_parse_mesh(input)
 
-    # Check that we have the parts stored separately
-    @test haskey(mesh, "parts")
-    @test haskey(mesh["parts"], "PART1")
-    @test haskey(mesh["parts"], "PART2")
+    @test sort(collect(keys(mesh["parts"]))) == ["PART1", "PART2"]
+    @test sort(collect(keys(mesh["assembly"]["instances"]))) ==
+        ["INST1", "INST2"]
+    @test mesh["instance_parts"] == Dict(
+        "INST1" => "PART1",
+        "INST2" => "PART2",
+    )
+    @test mesh["assembly"]["instances"]["INST1"]["translation"] ==
+        [0.0, 0.0, 0.0]
+    @test mesh["assembly"]["instances"]["INST2"]["translation"] ==
+        [2.0, 0.0, 0.0]
 
-    # Check PART1 data
-    @test length(mesh["parts"]["PART1"]["nodes"]) == 4
-    @test length(mesh["parts"]["PART1"]["elements"]) == 1
-    @test haskey(mesh["parts"]["PART1"]["element_sets"], "EPART1")
+    @test length(mesh["nodes"]) == 8
+    @test length(mesh["elements"]) == 2
+    @test mesh["nodes"][1] ≈ [0.0, 0.0, 0.0]
+    @test mesh["nodes"][4] ≈ [0.0, 1.0, 0.0]
+    @test mesh["nodes"][5] ≈ [2.0, 0.0, 0.0]
+    @test mesh["nodes"][7] ≈ [3.0, 1.0, 0.0]
+    @test mesh["elements"][1] == [1, 2, 3, 4]
+    @test mesh["elements"][2] == [5, 6, 7, 8]
+    @test mesh["element_types"] == Dict(1 => :Quad4, 2 => :Quad4)
+    @test mesh["element_codes"] == Dict(1 => :CPS4, 2 => :CPS4)
 
-    # Check PART2 data
-    @test length(mesh["parts"]["PART2"]["nodes"]) == 4
-    @test length(mesh["parts"]["PART2"]["elements"]) == 1
-    @test haskey(mesh["parts"]["PART2"]["element_sets"], "EPART2")
-
-    # Check flattened mesh (backward compatibility)
-    @test haskey(mesh, "nodes")
-    @test haskey(mesh, "elements")
-    @test length(mesh["nodes"]) == 8  # 4 from each part
-    @test length(mesh["elements"]) == 2  # 1 from each part
-
-    # Check that element sets are prefixed with part name
-    @test haskey(mesh["element_sets"], "PART1.EPART1")
-    @test haskey(mesh["element_sets"], "PART2.EPART2")
-
-    # Check that surface sets are preserved and prefixed with part name
-    @test haskey(mesh["surface_sets"], "PART1.LOADP1")
-    @test haskey(mesh["surface_sets"], "PART2.LOADP2")
-    @test mesh["surface_sets"]["PART1.LOADP1"] == [(1, :S1)]
-    @test mesh["surface_sets"]["PART2.LOADP2"] == [(2, :S1)]  # element offset applied
-    @test mesh["surface_types"]["PART1.LOADP1"] == :ELEMENT
-    @test mesh["surface_types"]["PART2.LOADP2"] == :ELEMENT
-
-    println("✓ PART/ASSEMBLY format mesh parsing works correctly")
+    @test mesh["element_sets"]["INST1.EPART1"] == [1]
+    @test mesh["element_sets"]["INST2.EPART2"] == [2]
+    @test mesh["node_sets"]["INST1.CORNER"] == [1]
+    @test mesh["surface_sets"]["INST1.LOADP1"] == [(1, :S1)]
+    @test mesh["surface_sets"]["INST2.LOADP2"] == [(2, :S1)]
+    @test mesh["surface_types"]["INST1.LOADP1"] == :ELEMENT
+    @test mesh["surface_types"]["INST2.LOADP2"] == :ELEMENT
 end
 
-@testset "Flat format works (for comparison)" begin
-    # Traditional flat format without PART/ASSEMBLY (this should work)
-    inp_content = """
+@testset "One part can be instantiated repeatedly" begin
+    input = """
+    *PART, NAME=PLATE
+    *NODE
+    1, 0.0, 0.0, 0.0
+    2, 1.0, 0.0, 0.0
+    3, 1.0, 1.0, 0.0
+    4, 0.0, 1.0, 0.0
+    *ELEMENT, TYPE=S4, ELSET=ALL
+    1, 1, 2, 3, 4
+    *SURFACE, TYPE=ELEMENT, NAME=TOP
+    1, S1
+    *END PART
+    *ASSEMBLY, NAME=A
+    *INSTANCE, NAME=LEFT, PART=PLATE
+    *END INSTANCE
+    *INSTANCE, NAME=RIGHT, PART=PLATE
+    10.0, 0.0, 0.0
+    *END INSTANCE
+    *END ASSEMBLY
+    """
+
+    mesh = abaqus_parse_mesh(input)
+    @test mesh["instance_parts"] == Dict(
+        "LEFT" => "PLATE",
+        "RIGHT" => "PLATE",
+    )
+    @test length(mesh["nodes"]) == 8
+    @test length(mesh["elements"]) == 2
+    @test mesh["nodes"][1] ≈ [0.0, 0.0, 0.0]
+    @test mesh["nodes"][5] ≈ [10.0, 0.0, 0.0]
+    @test mesh["element_codes"][1] == :S4
+    @test mesh["element_codes"][2] == :S4
+    @test mesh["element_sets"]["LEFT.ALL"] == [1]
+    @test mesh["element_sets"]["RIGHT.ALL"] == [2]
+    @test mesh["surface_sets"]["LEFT.TOP"] == [(1, :S1)]
+    @test mesh["surface_sets"]["RIGHT.TOP"] == [(2, :S1)]
+end
+
+@testset "Translation is applied before axis-angle rotation" begin
+    input = """
+    *PART, NAME=BAR
+    *NODE
+    1, 1.0, 0.0, 0.0
+    2, 2.0, 0.0, 0.0
+    *ELEMENT, TYPE=B31, ELSET=BAR
+    1, 1, 2
+    *END PART
+    *ASSEMBLY, NAME=A
+    *INSTANCE, NAME=ROTATED, PART=BAR
+    1.0, 0.0, 0.0
+    0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 90.0
+    *END INSTANCE
+    *END ASSEMBLY
+    """
+
+    mesh = abaqus_parse_mesh(input)
+    @test mesh["nodes"][1] ≈ [0.0, 2.0, 0.0] atol=1.0e-12
+    @test mesh["nodes"][2] ≈ [0.0, 3.0, 0.0] atol=1.0e-12
+    rotation = mesh["assembly"]["instances"]["ROTATED"]["rotation"]
+    @test rotation["axis_start"] == [0.0, 0.0, 0.0]
+    @test rotation["axis_end"] == [0.0, 0.0, 1.0]
+    @test rotation["angle_degrees"] == 90.0
+end
+
+@testset "PART-only assembly input retains deterministic fallback" begin
+    input = """
+    *PART, NAME=ONLY
+    *NODE
+    1, 0.0, 0.0, 0.0
+    2, 1.0, 0.0, 0.0
+    3, 0.0, 1.0, 0.0
+    *ELEMENT, TYPE=S3, ELSET=FACE
+    1, 1, 2, 3
+    *END PART
+    """
+
+    mesh = abaqus_parse_mesh(input)
+    @test isempty(mesh["assembly"]["instances"])
+    @test isempty(mesh["instance_parts"])
+    @test mesh["element_sets"]["ONLY.FACE"] == [1]
+    @test mesh["nodes"][1] == [0.0, 0.0, 0.0]
+end
+
+@testset "Flat format still works" begin
+    input = """
     *HEADING
     Flat format model
     *NODE
@@ -89,24 +168,66 @@ end
     2, 1.0, 0.0, 0.0
     3, 1.0, 1.0, 0.0
     4, 0.0, 1.0, 0.0
-    5, 2.0, 0.0, 0.0
-    6, 3.0, 0.0, 0.0
-    7, 3.0, 1.0, 0.0
-    8, 2.0, 1.0, 0.0
-    *ELEMENT,TYPE=CPS4,ELSET=PART1
+    *ELEMENT, TYPE=CPS4, ELSET=PART1
     1, 1, 2, 3, 4
-    *ELEMENT,TYPE=CPS4,ELSET=PART2
-    2, 5, 6, 7, 8
     """
 
-    # Mesh parsing should work
-    mesh = abaqus_parse_mesh(inp_content)
-    @test haskey(mesh, "nodes")
-    @test haskey(mesh, "elements")
-    @test length(mesh["nodes"]) == 8
-    @test length(mesh["elements"]) == 2
-    @test haskey(mesh["element_sets"], "PART1")
-    @test haskey(mesh["element_sets"], "PART2")
+    mesh = abaqus_parse_mesh(input)
+    @test length(mesh["nodes"]) == 4
+    @test length(mesh["elements"]) == 1
+    @test mesh["element_sets"]["PART1"] == [1]
+end
 
-    println("✓ Flat format mesh parsing works correctly")
+@testset "Malformed instance declarations fail clearly" begin
+    unknown_part = """
+    *PART, NAME=KNOWN
+    *NODE
+    1, 0.0, 0.0, 0.0
+    *END PART
+    *ASSEMBLY, NAME=A
+    *INSTANCE, NAME=BAD, PART=MISSING
+    *END INSTANCE
+    *END ASSEMBLY
+    """
+    @test_throws ArgumentError abaqus_parse_mesh(unknown_part)
+
+    duplicate_instance = """
+    *PART, NAME=P
+    *NODE
+    1, 0.0, 0.0, 0.0
+    *END PART
+    *ASSEMBLY, NAME=A
+    *INSTANCE, NAME=SAME, PART=P
+    *END INSTANCE
+    *INSTANCE, NAME=SAME, PART=P
+    *END INSTANCE
+    *END ASSEMBLY
+    """
+    @test_throws ArgumentError abaqus_parse_mesh(duplicate_instance)
+
+    malformed_translation = """
+    *PART, NAME=P
+    *NODE
+    1, 0.0, 0.0, 0.0
+    *END PART
+    *ASSEMBLY, NAME=A
+    *INSTANCE, NAME=BAD, PART=P
+    1.0, 2.0
+    *END INSTANCE
+    *END ASSEMBLY
+    """
+    @test_throws ArgumentError abaqus_parse_mesh(malformed_translation)
+
+    zero_axis = """
+    *PART, NAME=P
+    *NODE
+    1, 1.0, 0.0, 0.0
+    *END PART
+    *ASSEMBLY, NAME=A
+    *INSTANCE, NAME=BAD, PART=P
+    0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 90.0
+    *END INSTANCE
+    *END ASSEMBLY
+    """
+    @test_throws ArgumentError abaqus_parse_mesh(zero_axis)
 end


### PR DESCRIPTION
## Summary

Flatten Abaqus assemblies by declared instances rather than by source PARTs alone.
This restores translated, rotated, and repeated geometry needed by downstream
scientific preview consumers.

## Changes

- parse `NAME` and `PART` from `*INSTANCE` records;
- parse optional three-value translation and seven-value axis-angle rotation;
- apply translation before rotation;
- flatten repeated instances with independent deterministic offsets;
- prefix node sets, element sets, and surfaces with instance names;
- retain `instance_parts` and exact placement metadata;
- retain legacy PART-name flattening when no instances are declared;
- reject malformed placement, duplicate instances, unknown parts, and zero-length
  rotation axes.

## Validation

Exact-head validation passed for
`c723661adc10e1eb001fc63566eb9c9c3bcab52f` in CI run #85
(`30927050788`):

- latest stable Julia on Linux x64 passed;
- latest stable Julia on Windows x64 passed;
- latest stable Julia on macOS x64 passed;
- latest stable Julia on Linux x86 passed;
- Julia 1.6 on Linux x64 passed;
- Julia nightly on Linux x64 passed;
- coverage processing and upload passed where enabled;
- documentation dependencies, build, and deployment passed.

The regression suite covers translated assemblies, repeated instances,
translation-before-rotation semantics, PART-only fallback, flat-format
compatibility, set and surface preservation, and malformed declarations.

## Exact candidate

```text
c723661adc10e1eb001fc63566eb9c9c3bcab52f
```

Closes #77.

Downstream prerequisite for `ahojukka5/Maudslay.jl#92`.