### PR TITLE
ci: use only self-hosted Linux runners

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,7 +7,6 @@ on:
   pull_request:
   workflow_dispatch:
 
-# Cancel in-progress CI runs for the same PR/branch
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -17,36 +16,22 @@ permissions:
   actions: read
 
 jobs:
-
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
-    runs-on: ${{ matrix.os }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.arch }}
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: self-hosted
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        version:
-          - '1.6'  # LTS version
-          - '1'    # Latest stable
-        os:
-          - ubuntu-latest
-        arch:
-          - x64
         include:
-          # Test on different architectures with latest Julia
+          - version: '1.6'
+            arch: x64
           - version: '1'
-            os: ubuntu-latest
+            arch: x64
+          - version: '1'
             arch: x86
-          # Test on different OS with latest Julia
-          - version: '1'
-            os: macOS-latest
-            arch: x64
-          - version: '1'
-            os: windows-latest
-            arch: x64
-          # Allow nightly to fail
           - version: 'nightly'
-            os: ubuntu-latest
             arch: x64
     continue-on-error: ${{ matrix.version == 'nightly' || matrix.version == '1.6' }}
     steps:
@@ -59,20 +44,20 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-        if: matrix.version == '1' && matrix.os == 'ubuntu-latest' && matrix.arch == 'x64'
+        if: matrix.version == '1' && matrix.arch == 'x64'
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
-        if: matrix.version == '1' && matrix.os == 'ubuntu-latest' && matrix.arch == 'x64'
+        if: matrix.version == '1' && matrix.arch == 'x64'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 
   docs:
     name: Documentation
-    runs-on: ubuntu-latest
+    if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && !cancelled()
+    runs-on: self-hosted
     timeout-minutes: 20
     needs: test
-    if: ${{ !cancelled() }}
     permissions:
       contents: write
       statuses: write

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -23,7 +23,7 @@ permissions:
 jobs:
   TagBot:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: JuliaRegistries/TagBot@v1
         with:


### PR DESCRIPTION
## Summary

- replace the GitHub-hosted Linux/macOS/Windows test matrix with the portfolio's self-hosted Linux runner;
- preserve Julia 1.6/latest/nightly and x64/x86 coverage on Linux;
- run documentation and TagBot on self-hosted capacity as well;
- skip self-hosted test/docs work before scheduling for fork pull requests.

There is no self-hosted macOS or Windows pool, so those historical GitHub-hosted platform legs are removed rather than emulated on Linux. No existing runner-policy issue was found, so this PR does not create one solely for bookkeeping.